### PR TITLE
Adds Github actions workflow for exe creation and docker image build/push

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist
+          asset_path: ./dist/mimosa.exe
           asset_name: mimosa.exe
           asset_content_type: application/octet-stream
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build executable
         run: |
-          pyinstaller --onefile app.py --name mimosa
+          pyinstaller --onefile app.py --name mimosa.exe
       - name: test_ouput
         run: ls -la ./dist
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,83 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - Main
+  create:
+    tags:
+      - "v*" # Trigger on new tags
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt  # Replace with your requirements file
+
+      - name: Determine version
+        id: version
+        run: echo "::set-output name=version::$(if [ -n "$GITHUB_REF" ]; then echo $GITHUB_REF | awk -F/ '{print $3}'; else echo "1.0.$(git rev-list --count HEAD)-$(echo ${{ github.sha }} | head -c7)"; fi)"
+
+      - name: Build executable
+        run: |
+          # Replace "your_script.py" with the name of your main Python script
+          # Replace "output_file_name" with the desired name of the .exe file
+          pyinstaller --onefile your_script.py --name output_file_name
+
+      - name: Set outputs
+        id: outputs
+        run: echo "upload_url=$(echo ${{ github.event.repository.releases.url }} | sed 's/{\/id}//')" >> $GITHUB_ENV
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Determine version
+        id: version
+        run: echo "::set-output name=version::$(if [ -n "$GITHUB_REF" ]; then echo $GITHUB_REF | awk -F/ '{print $3}'; else echo "1.0.$(git rev-list --count HEAD)-$(echo ${{ github.sha }} | head -c7)"; fi)"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile # Replace with the path to your Dockerfile
+          platforms: linux/amd64,linux/arm64 # Adjust the platforms as needed
+          push: true
+          tags: |
+            tpickett/mimosa:latest
+            tpickett/mimosa:${{ steps.version.outputs.version }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ env.upload_url }}
+          asset_path: ./dist/output_file_name
+          asset_name: output_file_name.exe
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,11 +99,13 @@ jobs:
             Test Release ${{ needs.build.outputs.version }}
           draft: false
           prerelease: false
+      - name: test
+        run: ls -la ./dist
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/mimosa-exe
+          asset_path: ./dist
           asset_name: mimosa.exe
           asset_content_type: application/octet-stream
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: mimosa.exe
-          path: ./dist/mimosa/mimosa.exe
+          path: ./dist/mimosa.exe
 
       - name: Determine version
         id: version

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,12 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.upload_url.outputs.upload_url }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
@@ -36,6 +37,10 @@ jobs:
       - name: Build executable
         run: |
           pyinstaller --onefile app.py --name mimosa
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mimosa
+          path: dist/mimosa/mimosa.exe
 
       - name: Upload URL generation
         id: upload_url
@@ -58,9 +63,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Determine version
-        id: version
-        run: echo "::set-output name=version::$(if [ -n "$GITHUB_REF" ]; then echo $GITHUB_REF | awk -F/ '{print $3}'; else echo "1.0.$(git rev-list --count HEAD)-$(echo ${{ github.sha }} | head -c7)"; fi)"
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -70,12 +72,25 @@ jobs:
           push: true
           tags: |
             tpickett/mimosa:latest
-            tpickett/mimosa:${{ steps.version.outputs.version }}
+            tpickett/mimosa:${{ needs.build.outputs.version }}
 
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.build.outputs.version }}
+          release_name: ${{ needs.build.outputs.version }}
+          overwrite: true
+          body: |
+            Test Release ${{ needs.build.outputs.version }}
+          draft: false
+          prerelease: false
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,8 +103,8 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist
-          asset_name: mimosa-exe/mimosa.exe
+          asset_path: ./dist/mimosa-exe
+          asset_name: mimosa.exe
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,8 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      version: v${{ steps.version.outputs.major }}-${{ steps.version.outputs.minor }}-${{ steps.version.outputs.patch }}
+      version: v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,9 +49,6 @@ jobs:
           minor_pattern: "feat:"
           format: "${major}.${minor}.${patch}"
           bump_each_commit: false
-      - name: Upload URL generation
-        id: upload_url
-        run: echo "upload_url=$(echo ${{ github.event.repository.releases.url }} | sed 's/{\/id}//')" >> $GITHUB_OUTPUT
 
   docker:
     runs-on: ubuntu-latest
@@ -102,7 +98,7 @@ jobs:
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         with:
-          upload_url: ${{ needs.build.outputs.upload_url }}
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./dist
           asset_name: mimosa.exe
           asset_content_type: application/octet-stream

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,10 +33,12 @@ jobs:
       - name: Build executable
         run: |
           pyinstaller --onefile app.py --name mimosa
-      - uses: actions/upload-artifact@v2
+      - name: test_ouput
+        run: ls -la ./dist
+      - uses: actions/upload-artifact@v3
         with:
-          name: mimosa
-          path: dist/mimosa.exe
+          name: mimosa.exe
+          path: ./dist/mimosa/mimosa.exe
 
       - name: Determine version
         id: version

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    outputs:
+      upload_url: ${{ steps.upload_url.outputs.upload_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -36,8 +37,8 @@ jobs:
         run: |
           pyinstaller --onefile app.py --name mimosa
 
-      - name: Set outputs
-        id: outputs
+      - name: Upload URL generation
+        id: upload_url
         run: echo "upload_url=$(echo ${{ github.event.repository.releases.url }} | sed 's/{\/id}//')" >> $GITHUB_ENV
 
   docker:
@@ -48,17 +49,20 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Determine version
         id: version
         run: echo "::set-output name=version::$(if [ -n "$GITHUB_REF" ]; then echo $GITHUB_REF | awk -F/ '{print $3}'; else echo "1.0.$(git rev-list --count HEAD)-$(echo ${{ github.sha }} | head -c7)"; fi)"
-
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile # Replace with the path to your Dockerfile
@@ -75,9 +79,9 @@ jobs:
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         with:
-          upload_url: ${{ env.upload_url }}
-          asset_path: ./dist/output_file_name
-          asset_name: output_file_name.exe
+          upload_url: ${{ needs.build.outputs.upload_url }}
+          asset_path: ./dist/mimosa
+          asset_name: mimosa.exe
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - Main
+      - feature/github-actions
   create:
     tags:
       - "v*" # Trigger on new tags

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,8 +75,8 @@ jobs:
           platforms: linux/amd64,linux/arm64 # Adjust the platforms as needed
           push: true
           tags: |
-            tpickett/mimosa:latest
-            tpickett/mimosa:${{ needs.build.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/mimosa:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/mimosa:${{ needs.build.outputs.version }}
 
   release:
     runs-on: ubuntu-latest
@@ -99,8 +99,6 @@ jobs:
             Test Release ${{ needs.build.outputs.version }}
           draft: false
           prerelease: false
-      - name: test
-        run: ls -la ./dist
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: mimosa
-          path: dist/mimosa/mimosa.exe
+          path: dist/mimosa.exe
 
       - name: Upload URL generation
         id: upload_url
@@ -95,7 +95,7 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ needs.build.outputs.upload_url }}
-          asset_path: ./dist/mimosa
+          asset_path: ./dist
           asset_name: mimosa.exe
           asset_content_type: application/octet-stream
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,10 +30,6 @@ jobs:
           pip install pyinstaller
           pip install -r requirements.txt
 
-      - name: Determine version
-        id: version
-        run: echo "::set-output name=version::$(if [ -n "$GITHUB_REF" ]; then echo $GITHUB_REF | awk -F/ '{print $3}'; else echo "1.0.$(git rev-list --count HEAD)-$(echo ${{ github.sha }} | head -c7)"; fi)"
-
       - name: Build executable
         run: |
           pyinstaller --onefile app.py --name mimosa
@@ -42,9 +38,13 @@ jobs:
           name: mimosa
           path: dist/mimosa.exe
 
+      - name: Determine version
+        id: version
+        run: echo "version=$(if [ -n \"$GITHUB_REF\" ]; then echo $GITHUB_REF | awk -F/ '{print $3}'; else echo \"1.0.$(git rev-list --count HEAD)-$(echo ${{ github.sha }} | head -c7)\"; fi)" >> $GITHUB_OUTPUT
+
       - name: Upload URL generation
         id: upload_url
-        run: echo "upload_url=$(echo ${{ github.event.repository.releases.url }} | sed 's/{\/id}//')" >> $GITHUB_ENV
+        run: echo "upload_url=$(echo ${{ github.event.repository.releases.url }} | sed 's/{\/id}//')" >> $GITHUB_OUTPUT
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.upload_url.outputs.upload_url }}
-      version: ${{ steps.version.outputs.version }}
+      version: v${{ steps.version.outputs.major }}-${{ steps.version.outputs.minor }}-${{ steps.version.outputs.patch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -33,17 +35,21 @@ jobs:
       - name: Build executable
         run: |
           pyinstaller --onefile app.py --name mimosa.exe
-      - name: test_ouput
-        run: ls -la ./dist
+
       - uses: actions/upload-artifact@v3
         with:
           name: mimosa.exe
           path: ./dist/mimosa.exe
 
       - name: Determine version
+        uses: PaulHatch/semantic-version@v5.3.0
         id: version
-        run: echo "version=$(if [ -n \"$GITHUB_REF\" ]; then echo $GITHUB_REF | awk -F/ '{print $3}'; else echo \"1.0.$(git rev-list --count HEAD)-$(echo ${{ github.sha }} | head -c7)\"; fi)" >> $GITHUB_OUTPUT
-
+        with:
+          tag_prefix: "v"
+          major_pattern: "BREAKING CHANGE"
+          minor_pattern: "feat:"
+          format: "${major}.${minor}.${patch}"
+          bump_each_commit: false
       - name: Upload URL generation
         id: upload_url
         run: echo "upload_url=$(echo ${{ github.event.repository.releases.url }} | sed 's/{\/id}//')" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - Main
-      - feature/github-actions
-  create:
-    tags:
-      - "v*" # Trigger on new tags
 
 jobs:
   build:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: mimosa.exe
+          name: mimosa-exe
           path: ./dist/mimosa.exe
 
       - name: Determine version
@@ -82,6 +82,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: mimosa-exe
+          path: ./dist
       - name: create release
         id: create_release
         uses: actions/create-release@v1
@@ -100,7 +104,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./dist
-          asset_name: mimosa.exe
+          asset_name: mimosa-exe/mimosa.exe
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,9 +32,9 @@ jobs:
 
       - name: Build executable
         run: |
-          # Replace "your_script.py" with the name of your main Python script
+          # Replace "app.py" with the name of your main Python script
           # Replace "output_file_name" with the desired name of the .exe file
-          pyinstaller --onefile your_script.py --name output_file_name
+          pyinstaller --onefile app.py --name output_file_name
 
       - name: Set outputs
         id: outputs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt  # Replace with your requirements file
+          pip install pyinstaller
+          pip install -r requirements.txt
 
       - name: Determine version
         id: version
@@ -33,9 +34,7 @@ jobs:
 
       - name: Build executable
         run: |
-          # Replace "app.py" with the name of your main Python script
-          # Replace "output_file_name" with the desired name of the .exe file
-          pyinstaller --onefile app.py --name output_file_name
+          pyinstaller --onefile app.py --name mimosa
 
       - name: Set outputs
         id: outputs

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./app.py" ]

--- a/dockerfile
+++ b/dockerfile
@@ -7,4 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+EXPOSE 5000 
+
 CMD [ "python", "./app.py" ]


### PR DESCRIPTION
This workflow will produce a Git Tag, Github Release - with exe included, docker image and pushes it to a dockerhub repository with any pushed code to the `Main` branch.

It uses [semantic-version](https://github.com/PaulHatch/semantic-version) to auto generate the versions for the release and the docker image. with this you can bump the major, minor, or patch parts of the version with a simple pre or postfix to you git messages - i.e. `(MAJOR) my commit message`, `(MINOR) my commit message`

You will need a [dockerhub](https://hub.docker.com) account and token saved as repository secrets (DOCKERHUB_USERNAME and 
DOCKERHUB_TOKEN) so the workflow will push to your docker image repo correctly . 

I most definitely need to visit the exe creation - as i don't know how your creating it now. Im just using `pyinstaller` to create it with just the `app.py` file.

run output from my fork: https://github.com/tpickett/M.I.M.O.S.A/actions/runs/6853142582