### PR TITLE
setup Docker images and actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+.git
+.gitignore
+dist
+data
+**/node_modules
+client/build
+examples
+.env
+docker-compose.*
+.github
+.gitea
+**/*.test.ts*
+renovate.json
+Dockerfile*
+*.bat

--- a/.github/DISCUSSION_TEMPLATE/feature-request.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-request.yml
@@ -1,0 +1,24 @@
+title: "[Feature] feature-name-goes-here"
+labels: [ "feature" ]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please use this form to request a new feature or enhancement for Spotlight_Storage.
+        Stick to only a single feature per request. If you list multiple different features at once, 
+        your request will be closed.
+
+  - type: checkboxes
+    attributes:
+      label: I have searched the existing feature requests to make sure this is not a duplicate request.
+      options:
+        - label: "Yes"
+          required: true
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: The feature
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/feature_request.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+title: "[Feature] feature-name-goes-here"
+labels: [ "feature" ]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please use this form to request a new feature or enhancement for Spotlight_Storage.
+        Stick to only a single feature per request. If you list multiple different features at once, 
+        your request will be closed.
+
+  - type: checkboxes
+    attributes:
+      label: I have searched the existing feature requests to make sure this is not a duplicate request.
+      options:
+        - label: "Yes"
+          required: true
+
+  - type: textarea
+    id: feature
+    attributes:
+      label: The feature
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Report an issue with Spotlight_Storage
+description: Report an issue with Spotlight_Storage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue form is for reporting bugs only!
+
+        If you have a feature or enhancement request, please use the [feature request][fr] section of our [GitHub Discussions][fr].
+
+        [fr]: https://github.com/devzwf/Spotlight_Storage/discussions/new?category=feature-request
+
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: The bug
+      description: >-
+        Describe the issue you are experiencing here. Tell us what you were trying to do and what happened.
+
+        Provide a clear and concise description of what the problem is.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Environment
+
+  - type: input
+    validations:
+      required: true
+    attributes:
+      label: Operating System that is running Spotlight_Storage
+      placeholder: Windows, macOS, Linux (Ubuntu, Fedora, etc.)
+
+  - type: input
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: Spotlight_Storage Version
+      placeholder: v0.0.3
+
+  - type: textarea
+    validations:
+      required: false
+    attributes:
+      label: Your docker-compose.yml content
+      render: YAML
+
+  - type: textarea
+    validations:
+      required: false
+    attributes:
+      label: Your .env content
+      description: If you have any sensitive information in your .env file, please remove it before pasting here.
+      render: Shell
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: "How do you trigger this bug? Please walk us through it step by step."
+      value: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant logs below.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: >
+        If you have any additional information for us, use the field below.
+
+  - type: markdown
+    attributes:
+      value: Thank you for submitting the form

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature Request
+    url: https://github.com/devzwf/Spotlight_Storage/discussions/new?category=feature-request
+    about: Please use this form to request a new feature or enhancement for Spotlight_Storage.

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: |

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -32,6 +32,7 @@ jobs:
             linux/amd64
             linux/arm/v8
             linux/arm/v7
+            linux/arm/v6
           push: true
           provenance: false
           tags: ${{ vars.DOCKERHUB_TAG }}:dev

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,37 @@
+name: Build and deploy images
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: |
+            linux/arm64
+            linux/amd64
+            linux/arm/v8
+            linux/arm/v7
+          push: true
+          provenance: false
+          tags: ${{ vars.DOCKERHUB_TAG }}:dev

--- a/Dockerfile.old
+++ b/Dockerfile.old
@@ -1,0 +1,18 @@
+FROM python:3.13
+
+COPY static static
+COPY app.py  app.py
+COPY db.py db.py
+COPY favicon.ico favicon.ico
+COPY requirements.txt requirements.txt
+COPY templates templates
+COPY setup.py setup.py
+ENV TRANSLATIONS_DIR=/app/static/translations
+
+
+RUN pip install -r requirements.txt
+RUN python setup.py
+
+EXPOSE 5000
+EXPOSE 5001
+ENTRYPOINT python app.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+## Shell setting
+if [[ -n "$DEBUG" ]]; then
+    set -ex
+else
+    set -e
+fi
+
+cd /app && python ./app.py

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+rm -rf /app/requirements.txt /app/entrypoint.sh /app/.dockerignore
+
+sed -i 's/debug=True/debug=False/g'  /app/app.py
+sed -i "s/MIMOSA_VERSION/$MIMOSA_VERSION/g"  /app/app.py


### PR DESCRIPTION
This PR adds a Github Actions workflow for building and publishing Docker images for amd64, arm64 , arm/v6,  arm/v7 and arm/v8platforms. 
The workflow is set up to be manually triggered, however in the future as soon as we have a clear path of release and versioning this can be updated to be more automated

I've tested this myself and the resulting images are currently available for testing at: [my docker hub](https://hub.docker.com/r/devzwf/spotlight_storage/tags)

Unfortunately I don't currently have a machine available to test arm/v6, arm/v7 and arm/v8.

For now the image is pushed with tag : dev

Setup
Add the following repository secrets and variables, added through Settings > Secrets and Variables > Actions:

Secrets: `DOCKERHUB_USERNAME`,`DOCKERHUB_TOKEN`
Variables: `DOCKERHUB_TAG`

Docker Hub username and token can be generated by creating a new Access Token at [Docker Hub > Account Settings > Security.](https://hub.docker.com/settings/security)

The value of DOCKERHUB_TAG will be the name of the image on Docker Hub, eg: `mellowlabs/spotlight_storage`

Of course this is just a starting point and can be optimized when you have a better versioning 